### PR TITLE
Feature/template rendering

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include MANIFEST.in *.md LICENSE *.sh
-recursive-include ordered_model *.json
+recursive-include ordered_model *.json *.html
 

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -27,10 +27,10 @@ class OrderedModelAdmin(admin.ModelAdmin):
             return update_wrapper(wrapper, view)
         return patterns('',
                         url(r'^(.+)/move-(up)/$', wrap(self.move_view),
-                            name='{app}_{model}_order_move_up'.format(**self.get_model_info())),
+                            name='{app}_{model}_order_up'.format(**self.get_model_info())),
 
                         url(r'^(.+)/move-(down)/$', wrap(self.move_view),
-                            name='{app}_{model}_order_move_down'.format(**self.get_model_info())),
+                            name='{app}_{model}_order_down'.format(**self.get_model_info())),
                         ) + super(OrderedModelAdmin, self).get_urls()
 
     def _get_changelist(self, request):
@@ -67,8 +67,8 @@ class OrderedModelAdmin(admin.ModelAdmin):
             'module_name': self.model._meta.module_name,
             'object_id': obj.id,
             'urls': {
-                'up': reverse("admin:{app}_{model}_order_move_up".format(**self.get_model_info()), args=[obj.id, 'up']),
-                'down': reverse("admin:{app}_{model}_order_move_down".format(**self.get_model_info()), args=[obj.id, 'down']),
+                'up': reverse("admin:{app}_{model}_order_up".format(**self.get_model_info()), args=[obj.id, 'up']),
+                'down': reverse("admin:{app}_{model}_order_down".format(**self.get_model_info()), args=[obj.id, 'down']),
             },
             'query_string': self.request_query_string
         })

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from distutils.core import setup
- 
+# from distutils.core import setup
+from setuptools import setup, find_packages
+
 setup(
     name='django-ordered-model',
     version='0.3.0',
@@ -9,10 +10,8 @@ setup(
     author='Ben Firshman',
     author_email='ben@firshman.co.uk',
     url='http://github.com/bfirsh/django-ordered-model/',
-    packages=[
-        'ordered_model',
-        'ordered_model.tests',
-    ],
+    packages=find_packages(),
+    include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
@@ -20,11 +19,5 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-    ],
-    package_data={'ordered_model': ['static/ordered_model/arrow-up.gif',
-                                    'static/ordered_model/arrow-down.gif',
-                                    'locale/de/LC_MESSAGES/django.po',
-                                    'locale/de/LC_MESSAGES/django.mo',
-                                    'locale/pl/LC_MESSAGES/django.po',
-                                    'locale/pl/LC_MESSAGES/django.mo']}
+    ]
 )


### PR DESCRIPTION
missing manifest and setup changes required to install templates

- include_package_data=True allows the manifest to describe what non .py files to include
- find_packages removes the need to manually describe package names.
