### PR TITLE
Support multiple order_with_respect_to fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ A simple example might look like so:
         phone = models.CharField()
         order_with_respect_to = 'user'
 
+If objects are ordered with respect to more than one field, `order_with_respect_to` supports
+tuples to define multiple fields:
+
+    class Model(OrderedModel)
+        # ...
+        order_with_respect_to = ('field_a', 'field_b')
+
 
 Admin integration
 -----------------

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -10,15 +10,20 @@ class Question(models.Model):
     pass
 
 
+class User(models.Model):
+    pass
+
+
 class Answer(OrderedModel):
     question = models.ForeignKey(Question, related_name='answers')
-    order_with_respect_to = 'question'
+    user = models.ForeignKey(User, related_name='answers')
+    order_with_respect_to = ('question', 'user')
 
     class Meta:
-        ordering = ('question', 'order')
+        ordering = ('question', 'user', 'order')
 
     def __unicode__(self):
-        return u"Answer #%d of question #%d" % (self.order, self.question_id)
+        return u"Answer #%d of question #%d for user #%d" % (self.order, self.question_id, self.user_id)
 
 
 class CustomItem(OrderedModel):


### PR DESCRIPTION
There's no reason why `order_with_respect_to` should be limited to a single field.

This pull request implements the necessary changes to support multiple `order_with_respect_to` fields, along with additional tests and updated documentation.