### PR TITLE
Rename module_name to model_name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ env:
   - DJANGO="Django>=1.5,<1.6"
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
+  - DJANGO="Django>=1.8,<1.9"
 
 matrix:
   exclude:
     - python: "2.6"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "2.6"
+      env: DJANGO="Django>=1.8,<1.9"
 
 # command to install dependencies
 install: pip install $DJANGO --use-mirrors

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -8,16 +8,14 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 from django.contrib import admin
-from django.contrib.admin.util import unquote
+try:
+    from django.contrib.admin.utils import unquote
+except ImportError:
+    from django.contrib.admin.util import unquote
 from django.contrib.admin.views.main import ChangeList
 
 
 class OrderedModelAdmin(admin.ModelAdmin):
-
-    def get_model_info(self):
-        return dict(app=self.model._meta.app_label,
-                    model=self.model._meta.module_name)
-
     def get_urls(self):
         from django.conf.urls import patterns, url
 
@@ -26,12 +24,12 @@ class OrderedModelAdmin(admin.ModelAdmin):
                 return self.admin_site.admin_view(view)(*args, **kwargs)
             return update_wrapper(wrapper, view)
         return patterns('',
-                        url(r'^(.+)/move-(up)/$', wrap(self.move_view),
-                            name='{app}_{model}_order_up'.format(**self.get_model_info())),
+            url(r'^(.+)/move-(up)/$', wrap(self.move_view),
+                name='{app}_{model}_order_up'.format(**self._get_model_info())),
 
-                        url(r'^(.+)/move-(down)/$', wrap(self.move_view),
-                            name='{app}_{model}_order_down'.format(**self.get_model_info())),
-                        ) + super(OrderedModelAdmin, self).get_urls()
+            url(r'^(.+)/move-(down)/$', wrap(self.move_view),
+                name='{app}_{model}_order_down'.format(**self._get_model_info())),
+            ) + super(OrderedModelAdmin, self).get_urls()
 
     def _get_changelist(self, request):
         list_display = self.get_list_display(request)
@@ -62,15 +60,27 @@ class OrderedModelAdmin(admin.ModelAdmin):
         return HttpResponseRedirect('../../%s' % self.request_query_string)
 
     def move_up_down_links(self, obj):
+        model_info = self._get_model_info()
         return render_to_string("ordered_model/admin/order_controls.html", {
-            'app_label': self.model._meta.app_label,
-            'module_name': self.model._meta.module_name,
+            'app_label': model_info['app'],
+            'module_name': model_info['model'],
             'object_id': obj.id,
             'urls': {
-                'up': reverse("admin:{app}_{model}_order_up".format(**self.get_model_info()), args=[obj.id, 'up']),
-                'down': reverse("admin:{app}_{model}_order_down".format(**self.get_model_info()), args=[obj.id, 'down']),
+                'up': reverse("admin:{app}_{model}_order_up".format(**model_info), args=[obj.id, 'up']),
+                'down': reverse("admin:{app}_{model}_order_down".format(**model_info), args=[obj.id, 'down']),
             },
             'query_string': self.request_query_string
         })
     move_up_down_links.allow_tags = True
     move_up_down_links.short_description = _(u'Move')
+
+    def _get_model_info(self):
+        # module_name was renamed to model_name in Django 1.7
+        if hasattr(self.model._meta, 'model_name'):
+            model = self.model._meta.model_name
+        else:
+            model = self.model._meta.module_name
+        return {
+            'app': self.model._meta.app_label,
+            'model': model
+        }

--- a/ordered_model/tests/settings.py
+++ b/ordered_model/tests/settings.py
@@ -12,3 +12,11 @@ INSTALLED_APPS = [
     'ordered_model.tests',
 ]
 SECRET_KEY = 'topsecret'
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -1,4 +1,6 @@
+from django.contrib import admin
 from django.test import TestCase
+from ordered_model.admin import OrderedModelAdmin
 from ordered_model.tests.models import Answer, Item, Question, CustomItem
 import uuid
 
@@ -188,3 +190,12 @@ class CustomPKTest(TestCase):
                 (self.item4.pk, 3)
             ]
         )
+
+admin.site.register(Item, OrderedModelAdmin)
+
+class OrderedModelAdminTest(TestCase):
+    def test_move_up_down_links(self):
+        item = Item.objects.create(name='foo')
+        s = admin.site._registry[Item].move_up_down_links(item)
+        self.assertIn('/admin/tests/item/1/move-up/', s)
+        self.assertIn('/admin/tests/item/1/move-down/', s)

--- a/ordered_model/tests/urls.py
+++ b/ordered_model/tests/urls.py
@@ -1,4 +1,11 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls.defaults import *
+except ImportError:
+    from django.conf.urls import *
+from django.contrib import admin
+
+admin.autodiscover()
 
 urlpatterns = patterns('',
+    (r'^admin/', include(admin.site.urls)),
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django<1.8
+Django


### PR DESCRIPTION
Also add support for Django 1.8. Replaces #32 and #43.