### PR TITLE
Deprecated get_query_set renamed to get_queryset

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -52,7 +52,10 @@ class OrderedModelAdmin(admin.ModelAdmin):
 
     def move_view(self, request, object_id, direction):
         cl = self._get_changelist(request)
-        qs = cl.get_query_set(request)
+
+        # support get_query_set for backward compatibility
+        get_queryset = getattr(cl, 'get_queryset', None) or getattr(cl, 'get_query_set')
+        qs = get_queryset(request)
 
         obj = get_object_or_404(self.model, pk=unquote(object_id))
         obj.move(direction, qs)


### PR DESCRIPTION
ChangeList#get_query_set was deprecated and finally removed in Django 1.8.
ChangeList#get_queryset is the correct method name now.