### PR TITLE
support for custom order field name

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -40,7 +40,7 @@ class OrderedModelBase(models.Model):
 
     def save(self, *args, **kwargs):
         if getattr(self, self.order_field_name) is None:
-            c = self.get_ordering_queryset().aggregate(Max(self.order_field_name)).get('{}__max'.format(self.order_field_name))
+            c = self.get_ordering_queryset().aggregate(Max(self.order_field_name)).get(self.order_field_name + '__max')
             setattr(self, self.order_field_name, 0 if c is None else c + 1)
         super(OrderedModelBase, self).save(*args, **kwargs)
 
@@ -53,7 +53,7 @@ class OrderedModelBase(models.Model):
         qs = self.get_ordering_queryset(qs)
 
         if up:
-            qs = qs.order_by('-{}'.format(self.order_field_name)).filter(order__lt=getattr(self, self.order_field_name))
+            qs = qs.order_by('-' + self.order_field_name).filter(order__lt=getattr(self, self.order_field_name))
         else:
             qs = qs.filter(order__gt=getattr(self, self.order_field_name))
         try:
@@ -119,7 +119,7 @@ class OrderedModelBase(models.Model):
         """
         Move this object up one position.
         """
-        self.swap(self.get_ordering_queryset().filter(order__lt=getattr(self, self.order_field_name)).order_by('-{}'.format(self.order_field_name)))
+        self.swap(self.get_ordering_queryset().filter(order__lt=getattr(self, self.order_field_name)).order_by('-' + self.order_field_name))
 
     def down(self):
         """
@@ -158,7 +158,7 @@ class OrderedModelBase(models.Model):
         if getattr(self, self.order_field_name) > ref.order:
             o = ref.order
         else:
-            o = self.get_ordering_queryset().filter(order__lt=ref.order).aggregate(Max(self.order_field_name)).get('{}__max'.format(self.order_field_name)) or 0
+            o = self.get_ordering_queryset().filter(order__lt=ref.order).aggregate(Max(self.order_field_name)).get(self.order_field_name + '__max') or 0
         self.to(o)
 
     def below(self, ref):
@@ -175,7 +175,7 @@ class OrderedModelBase(models.Model):
         if getattr(self, self.order_field_name) == ref.order:
             return
         if getattr(self, self.order_field_name) > ref.order:
-            o = self.get_ordering_queryset().filter(order__gt=ref.order).aggregate(Min(self.order_field_name)).get('{}__min'.format(self.order_field_name)) or 0
+            o = self.get_ordering_queryset().filter(order__gt=ref.order).aggregate(Min(self.order_field_name)).get(self.order_field_name + '__min') or 0
         else:
             o = ref.order
         self.to(o)
@@ -184,14 +184,14 @@ class OrderedModelBase(models.Model):
         """
         Move this object to the top of the ordered stack.
         """
-        o = self.get_ordering_queryset().aggregate(Min(self.order_field_name)).get('{}__min'.format(self.order_field_name))
+        o = self.get_ordering_queryset().aggregate(Min(self.order_field_name)).get(self.order_field_name + '__min')
         self.to(o)
 
     def bottom(self):
         """
         Move this object to the bottom of the ordered stack.
         """
-        o = self.get_ordering_queryset().aggregate(Max(self.order_field_name)).get('{}__max'.format(self.order_field_name))
+        o = self.get_ordering_queryset().aggregate(Max(self.order_field_name)).get(self.order_field_name + '__max')
         self.to(o)
 
 

--- a/ordered_model/tests/fixtures/test_items.json
+++ b/ordered_model/tests/fixtures/test_items.json
@@ -30,5 +30,37 @@
       "name": "4", 
       "order": 3
     }
+  },
+  {
+    "pk": 1,
+    "model": "tests.customorderfieldmodel",
+    "fields": {
+      "name": "1",
+      "sort_order": 0
+    }
+  },
+  {
+    "pk": 2,
+    "model": "tests.customorderfieldmodel",
+    "fields": {
+      "name": "2",
+      "sort_order": 1
+    }
+  },
+  {
+    "pk": 3,
+    "model": "tests.customorderfieldmodel",
+    "fields": {
+      "name": "3",
+      "sort_order": 2
+    }
+  },
+  {
+    "pk": 4,
+    "model": "tests.customorderfieldmodel",
+    "fields": {
+      "name": "4",
+      "sort_order": 3
+    }
   }
 ]

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -30,3 +30,6 @@ class CustomOrderFieldModel(OrderedModelBase):
     sort_order = models.PositiveIntegerField(editable=False, db_index=True)
     name = models.CharField(max_length=100)
     order_field_name = 'sort_order'
+
+    class Meta:
+        ordering = ('sort_order',)

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from ordered_model.models import OrderedModel
+from ordered_model.models import OrderedModel, OrderedModelBase
 
 
 class Item(OrderedModel):
@@ -24,3 +24,9 @@ class Answer(OrderedModel):
 class CustomItem(OrderedModel):
     id = models.CharField(max_length=100, primary_key=True)
     name = models.CharField(max_length=100)
+
+
+class CustomOrderFieldModel(OrderedModelBase):
+    sort_order = models.PositiveIntegerField(editable=False, db_index=True)
+    name = models.CharField(max_length=100)
+    order_field_name = 'sort_order'

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.test import TestCase
 from ordered_model.admin import OrderedModelAdmin
-from ordered_model.tests.models import Answer, Item, Question, CustomItem
+from ordered_model.tests.models import Answer, Item, Question, CustomItem, CustomOrderFieldModel
 import uuid
 
 class OrderGenerationTests(TestCase):
@@ -190,6 +190,25 @@ class CustomPKTest(TestCase):
                 (self.item4.pk, 3)
             ]
         )
+
+
+class CustomOrderFieldTest(TestCase):
+    def setUp(self):
+        self.item1 = CustomOrderFieldModel.objects.create(name='1')
+        self.item2 = CustomOrderFieldModel.objects.create(name='2')
+        self.item3 = CustomOrderFieldModel.objects.create(name='3')
+        self.item4 = CustomOrderFieldModel.objects.create(name='4')
+
+    def test_saved_order(self):
+        self.assertSequenceEqual(
+            CustomOrderFieldModel.objects.values_list('pk', CustomOrderFieldModel.order_field_name), [
+                (self.item1.pk, 0),
+                (self.item2.pk, 1),
+                (self.item3.pk, 2),
+                (self.item4.pk, 3)
+            ]
+        )
+
 
 admin.site.register(Item, OrderedModelAdmin)
 

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -193,21 +193,84 @@ class CustomPKTest(TestCase):
 
 
 class CustomOrderFieldTest(TestCase):
-    def setUp(self):
-        self.item1 = CustomOrderFieldModel.objects.create(name='1')
-        self.item2 = CustomOrderFieldModel.objects.create(name='2')
-        self.item3 = CustomOrderFieldModel.objects.create(name='3')
-        self.item4 = CustomOrderFieldModel.objects.create(name='4')
+    fixtures = ['test_items.json']
 
-    def test_saved_order(self):
-        self.assertSequenceEqual(
-            CustomOrderFieldModel.objects.values_list('pk', CustomOrderFieldModel.order_field_name), [
-                (self.item1.pk, 0),
-                (self.item2.pk, 1),
-                (self.item3.pk, 2),
-                (self.item4.pk, 3)
-            ]
-        )
+    def assertNames(self, names):
+        self.assertEqual(list(enumerate(names)), [(i.sort_order, i.name) for i in CustomOrderFieldModel.objects.all()])
+
+    def test_inserting_new_models(self):
+        CustomOrderFieldModel.objects.create(name='Wurble')
+        self.assertNames(['1', '2', '3', '4', 'Wurble'])
+
+    def test_up(self):
+        CustomOrderFieldModel.objects.get(pk=4).up()
+        self.assertNames(['1', '2', '4', '3'])
+
+    def test_up_first(self):
+        CustomOrderFieldModel.objects.get(pk=1).up()
+        self.assertNames(['1', '2', '3', '4'])
+
+    def test_up_with_gap(self):
+        CustomOrderFieldModel.objects.get(pk=3).up()
+        self.assertNames(['1', '3', '2', '4'])
+
+    def test_down(self):
+        CustomOrderFieldModel.objects.get(pk=1).down()
+        self.assertNames(['2', '1', '3', '4'])
+
+    def test_down_last(self):
+        CustomOrderFieldModel.objects.get(pk=4).down()
+        self.assertNames(['1', '2', '3', '4'])
+
+    def test_down_with_gap(self):
+        CustomOrderFieldModel.objects.get(pk=2).down()
+        self.assertNames(['1', '3', '2', '4'])
+
+    def test_to(self):
+        CustomOrderFieldModel.objects.get(pk=4).to(0)
+        self.assertNames(['4', '1', '2', '3'])
+        CustomOrderFieldModel.objects.get(pk=4).to(2)
+        self.assertNames(['1', '2', '4', '3'])
+        CustomOrderFieldModel.objects.get(pk=3).to(1)
+        self.assertNames(['1', '3', '2', '4'])
+
+    def test_top(self):
+        CustomOrderFieldModel.objects.get(pk=4).top()
+        self.assertNames(['4', '1', '2', '3'])
+        CustomOrderFieldModel.objects.get(pk=2).top()
+        self.assertNames(['2', '4', '1', '3'])
+
+    def test_bottom(self):
+        CustomOrderFieldModel.objects.get(pk=1).bottom()
+        self.assertNames(['2', '3', '4', '1'])
+        CustomOrderFieldModel.objects.get(pk=3).bottom()
+        self.assertNames(['2', '4', '1', '3'])
+
+    def test_above(self):
+        CustomOrderFieldModel.objects.get(pk=3).above(CustomOrderFieldModel.objects.get(pk=1))
+        self.assertNames(['3', '1', '2', '4'])
+        CustomOrderFieldModel.objects.get(pk=4).above(CustomOrderFieldModel.objects.get(pk=1))
+        self.assertNames(['3', '4', '1', '2'])
+
+    def test_above_self(self):
+        CustomOrderFieldModel.objects.get(pk=3).above(CustomOrderFieldModel.objects.get(pk=3))
+        self.assertNames(['1', '2', '3', '4'])
+
+    def test_below(self):
+        CustomOrderFieldModel.objects.get(pk=1).below(CustomOrderFieldModel.objects.get(pk=3))
+        self.assertNames(['2', '3', '1', '4'])
+        CustomOrderFieldModel.objects.get(pk=3).below(CustomOrderFieldModel.objects.get(pk=4))
+        self.assertNames(['2', '1', '4', '3'])
+
+    def test_below_self(self):
+        CustomOrderFieldModel.objects.get(pk=2).below(CustomOrderFieldModel.objects.get(pk=2))
+        self.assertNames(['1', '2', '3', '4'])
+
+    def test_delete(self):
+        CustomOrderFieldModel.objects.get(pk=2).delete()
+        self.assertNames(['1', '3', '4'])
+        CustomOrderFieldModel.objects.get(pk=3).up()
+        self.assertNames(['3', '1', '4'])
 
 
 admin.site.register(Item, OrderedModelAdmin)


### PR DESCRIPTION
Proposed fix for #39 

OrderedModel inherits OrderedModelBase, to allow for custom naming of order fields.

It does hurt readability.  If there are any suggestions for mitigating that effect, i'm all ears.
