### PR TITLE
Fixes OrderedTabularInline.get_queryset() to work in newer versions of Django

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -174,12 +174,20 @@ class OrderedTabularInline(admin.TabularInline):
         Returns a QuerySet of all model instances that can be edited by the
         admin site. This is used by changelist_view.
         """
-        qs = cls.model._default_manager.get_queryset()
+        # support get_query_set for backward compatibility
+        get_queryset = getattr(cls.model._default_manager,
+                               'get_queryset', None) or getattr(cls.model._default_manager,
+                                                                'get_query_set')
+        qs = get_queryset()
         # TODO: this should be handled by some parameter to the ChangeList.
         ordering = cls.get_ordering(request)
         if ordering:
             qs = qs.order_by(*ordering)
         return qs
+
+    @classmethod
+    def get_query_set(cls, request):
+        return cls.get_queryset(request)
 
     @classmethod
     def get_ordering(cls, request):

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -174,7 +174,7 @@ class OrderedTabularInline(admin.TabularInline):
         Returns a QuerySet of all model instances that can be edited by the
         admin site. This is used by changelist_view.
         """
-        qs = cls.model._default_manager.get_query_set()
+        qs = cls.model._default_manager.get_queryset()
         # TODO: this should be handled by some parameter to the ChangeList.
         ordering = cls.get_ordering(request)
         if ordering:

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -185,6 +185,7 @@ class OrderedTabularInline(admin.TabularInline):
             qs = qs.order_by(*ordering)
         return qs
 
+    # support get_query_set for backward compatibility
     @classmethod
     def get_query_set(cls, request):
         return cls.get_queryset(request)


### PR DESCRIPTION
Adds missing check for get_query_set / get_queryset in OrderedTabularInline.get_queryset, also adds OrderedTabularInline.get_query_set to make class backwards-compatible.