### PR TITLE
Fix old-style get_query_set to get_queryset

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -160,7 +160,7 @@ class OrderedTabularInline(admin.TabularInline):
         Returns a QuerySet of all model instances that can be edited by the
         admin site. This is used by changelist_view.
         """
-        qs = cls.model._default_manager.get_query_set()
+        qs = cls.model._default_manager.get_queryset()
         # TODO: this should be handled by some parameter to the ChangeList.
         ordering = cls.get_ordering(request)
         if ordering:


### PR DESCRIPTION
Ok, now in a django-1.9 branch. But FYI, I'm using it on django 1.8.9.