### PR TITLE
Fix for above(), below() and to() to handle certain edge cases.

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -140,17 +140,13 @@ class OrderedModelBase(models.Model):
         """
         Move object to a certain position, updating all affected objects to move accordingly up or down.
         """
-        if order is None or getattr(self, self.order_field_name) == order:
-            # object is already at desired position
-            return
         qs = self.get_ordering_queryset()
-        if getattr(self, self.order_field_name) > order:
-            qs.filter(**{self.order_field_name + '__lt': getattr(self, self.order_field_name),
-                         self.order_field_name + '__gte': order})\
+        qs = qs.exclude(pk=self.pk)
+        if getattr(self, self.order_field_name) >= order:
+            qs.filter(**{self.order_field_name + '__gte': order})\
               .update(**{self.order_field_name: F(self.order_field_name) + 1})
         else:
-            qs.filter(**{self.order_field_name + '__gt': getattr(self, self.order_field_name),
-                         self.order_field_name + '__lte': order})\
+            qs.filter(**{self.order_field_name + '__lte': order})\
               .update(**{self.order_field_name: F(self.order_field_name) - 1})
         setattr(self, self.order_field_name, order)
         self.save()
@@ -165,9 +161,8 @@ class OrderedModelBase(models.Model):
                     self, self.__class__, ' and '.join(["'{}'".format(o[0]) for o in self._get_order_with_respect_to()])
                 )
             )
-        if getattr(self, self.order_field_name) == getattr(ref, self.order_field_name):
-            return
-        if getattr(self, self.order_field_name) > getattr(ref, self.order_field_name):
+
+        if getattr(self, self.order_field_name) >= getattr(ref, self.order_field_name):
             o = getattr(ref, self.order_field_name)
         else:
             o = self.get_ordering_queryset()\
@@ -186,9 +181,7 @@ class OrderedModelBase(models.Model):
                     self, self.__class__, ' and '.join(["'{}'".format(o[0]) for o in self._get_order_with_respect_to()])
                 )
             )
-        if getattr(self, self.order_field_name) == getattr(ref, self.order_field_name):
-            return
-        if getattr(self, self.order_field_name) > getattr(ref, self.order_field_name):
+        if getattr(self, self.order_field_name) >= getattr(ref, self.order_field_name):
             o = self.get_ordering_queryset()\
                     .filter(**{self.order_field_name + '__gt': getattr(ref, self.order_field_name)})\
                     .aggregate(Min(self.order_field_name))\


### PR DESCRIPTION
In the case that an item's 'get_respect_to' values have changed
(such as an ordered item being moved from one ordered list into another), the currently
assigned order might temporarily be the same as an already existing order value.
Because of that, we cannot assume that in a case where order==self.order that nothing must be done.
One option would be to look for duplicates and if no duplicates are found, then return.
Conceptually simpler though is to just .exclude() the 'self' from the queryset
which is used for the +1/-1 field updates of all items that are before or after.

An alternative to this patch is to require the calling application to
set a temporary 'order' value (perhaps MAXINT) before calling above(),
below(), or to().

-----

If this patch is misunderstanding the intention of this code, please comment.  Perhaps this is a good starting point - or at least a good starting point for discussion