### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -51,7 +51,7 @@ class OrderedModelAdmin(admin.ModelAdmin):
         obj = get_object_or_404(self.model, pk=unquote(object_id))
         obj.move(direction, qs)
 
-        return HttpResponseRedirect('../../%s' % self.request_query_string)
+        return HttpResponseRedirect('../../{0!s}'.format(self.request_query_string))
 
     def move_up_down_links(self, obj):
         model_info = self._get_model_info()
@@ -194,13 +194,13 @@ class OrderedTabularInline(admin.TabularInline):
         # Apply keyword searches.
         def construct_search(field_name):
             if field_name.startswith('^'):
-                return "%s__istartswith" % field_name[1:]
+                return "{0!s}__istartswith".format(field_name[1:])
             elif field_name.startswith('='):
-                return "%s__iexact" % field_name[1:]
+                return "{0!s}__iexact".format(field_name[1:])
             elif field_name.startswith('@'):
-                return "%s__search" % field_name[1:]
+                return "{0!s}__search".format(field_name[1:])
             else:
-                return "%s__icontains" % field_name
+                return "{0!s}__icontains".format(field_name)
 
         use_distinct = False
         search_fields = cls.get_search_fields(request)
@@ -226,7 +226,7 @@ class OrderedTabularInline(admin.TabularInline):
         obj = get_object_or_404(cls.model, pk=unquote(object_id))
         obj.move(direction, qs)
 
-        return HttpResponseRedirect('../../../%s' % cls.request_query_string)
+        return HttpResponseRedirect('../../../{0!s}'.format(cls.request_query_string))
 
     @classmethod
     def get_preserved_filters(cls, request):
@@ -236,8 +236,8 @@ class OrderedTabularInline(admin.TabularInline):
         match = request.resolver_match
         if cls.preserve_filters and match:
             opts = cls.model._meta
-            current_url = '%s:%s' % (match.app_name, match.url_name)
-            changelist_url = 'admin:%s_%s_changelist' % (opts.app_label, opts.model_name)
+            current_url = '{0!s}:{1!s}'.format(match.app_name, match.url_name)
+            changelist_url = 'admin:{0!s}_{1!s}_changelist'.format(opts.app_label, opts.model_name)
             if current_url == changelist_url:
                 preserved_filters = request.GET.urlencode()
             else:

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -116,7 +116,7 @@ class OrderedModelBase(models.Model):
             return
         if not self._valid_ordering_reference(replacement):
             raise ValueError(
-                "%r can only be swapped with instances of %r with equal %s fields." % (
+                "{0!r} can only be swapped with instances of {1!r} with equal {2!s} fields.".format(
                     self, self.__class__, ' and '.join(["'{}'".format(o[0]) for o in self._get_order_with_respect_to()])
                 )
             )
@@ -165,7 +165,7 @@ class OrderedModelBase(models.Model):
         """
         if not self._valid_ordering_reference(ref):
             raise ValueError(
-                "%r can only be swapped with instances of %r with equal %s fields." % (
+                "{0!r} can only be swapped with instances of {1!r} with equal {2!s} fields.".format(
                     self, self.__class__, ' and '.join(["'{}'".format(o[0]) for o in self._get_order_with_respect_to()])
                 )
             )
@@ -186,7 +186,7 @@ class OrderedModelBase(models.Model):
         """
         if not self._valid_ordering_reference(ref):
             raise ValueError(
-                "%r can only be swapped with instances of %r with equal %s fields." % (
+                "{0!r} can only be swapped with instances of {1!r} with equal {2!s} fields.".format(
                     self, self.__class__, ' and '.join(["'{}'".format(o[0]) for o in self._get_order_with_respect_to()])
                 )
             )

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -23,7 +23,7 @@ class Answer(OrderedModel):
         ordering = ('question', 'user', 'order')
 
     def __unicode__(self):
-        return u"Answer #%d of question #%d for user #%d" % (self.order, self.question_id, self.user_id)
+        return u"Answer #{0:d} of question #{1:d} for user #{2:d}".format(self.order, self.question_id, self.user_id)
 
 
 class CustomItem(OrderedModel):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bfirsh:django-ordered-model?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bfirsh:django-ordered-model?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)