### PR TITLE
Support additional arguments to update() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ the order value of all objects that were above the moved object by one.
 This sets the order value to the highest value found in the stack and decreases
 the order value of all objects that were below the moved object by one.
 
+### Updating fields that would be updated during save()
+
+For performance reasons, the delete(), to(), below(), above(), top(), and bottom()
+methods use Django's update() method to change the order of other objects that
+are shifted as a result of one of these calls. If the model has fields that
+are typically updated in a customized save() method, or through other app level 
+functionality such as DateTimeField(auto_now=True), you can add additional fields
+to be passed through to update(). This will only impact objects where their order
+is being shifted as a result of an operation on the target object, not the target
+object itself.
+
+    foo.to(12, extra_update={'modified': now()}
+ 
 ## Subset Ordering
 
 In some cases, ordering objects is required only on a subset of objects. For example,

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -29,6 +29,7 @@ class Answer(OrderedModel):
 class CustomItem(OrderedModel):
     id = models.CharField(max_length=100, primary_key=True)
     name = models.CharField(max_length=100)
+    modified = models.DateTimeField(null=True, blank=True)
 
 
 class CustomOrderFieldModel(OrderedModelBase):

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
+from django.utils.timezone import now
 from django.test import TestCase
 import uuid
 from ordered_model.tests.models import (
@@ -200,6 +201,87 @@ class CustomPKTest(TestCase):
                 (self.item2.pk, 1),
                 (self.item3.pk, 2),
                 (self.item4.pk, 3)
+            ]
+        )
+    
+    def test_order_to_extra_update(self):
+        modified_time = now()
+        self.item1.to(3, extra_update={'modified':modified_time})
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order', 'modified'), [
+                (self.item2.pk, 0, modified_time),
+                (self.item3.pk, 1, modified_time),
+                (self.item4.pk, 2, modified_time),
+                # This one is the primary item being operated on and modified would be 
+                # handled via auto_now or something
+                (self.item1.pk, 3, None)
+            ]
+        )
+    
+    def test_bottom_extra_update(self):
+        modified_time = now()
+        self.item1.bottom(extra_update={'modified':modified_time})
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order', 'modified'), [
+                (self.item2.pk, 0, modified_time),
+                (self.item3.pk, 1, modified_time),
+                (self.item4.pk, 2, modified_time),
+                # This one is the primary item being operated on and modified would be 
+                # handled via auto_now or something
+                (self.item1.pk, 3, None)
+            ]
+        )
+    
+    def test_top_extra_update(self):
+        modified_time = now()
+        self.item4.top(extra_update={'modified':modified_time})
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order', 'modified'), [
+                (self.item4.pk, 0, None),
+                (self.item1.pk, 1, modified_time),
+                (self.item2.pk, 2, modified_time),
+                # This one is the primary item being operated on and modified would be 
+                # handled via auto_now or something
+                (self.item3.pk, 3, modified_time)
+            ]
+        )
+    
+    def test_below_extra_update(self):
+        modified_time = now()
+        self.item1.below(self.item4, extra_update={'modified':modified_time})
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order', 'modified'), [
+                (self.item2.pk, 0, modified_time),
+                (self.item3.pk, 1, modified_time),
+                (self.item4.pk, 2, modified_time),
+                # This one is the primary item being operated on and modified would be 
+                # handled via auto_now or something
+                (self.item1.pk, 3, None)
+            ]
+        )
+    
+    def test_above_extra_update(self):
+        modified_time = now()
+        self.item4.above(self.item1, extra_update={'modified':modified_time})
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order', 'modified'), [
+                (self.item4.pk, 0, None),
+                (self.item1.pk, 1, modified_time),
+                (self.item2.pk, 2, modified_time),
+                # This one is the primary item being operated on and modified would be 
+                # handled via auto_now or something
+                (self.item3.pk, 3, modified_time)
+            ]
+        )
+    
+    def test_delete_extra_update(self):
+        modified_time = now()
+        self.item1.delete(extra_update={'modified':modified_time})
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order', 'modified'), [
+                (self.item2.pk, 0, modified_time),
+                (self.item3.pk, 1, modified_time),
+                (self.item4.pk, 2, modified_time),
             ]
         )
 


### PR DESCRIPTION
This was primarily added because my models all have a field defined as ```modified = DateTimeField(auto_now=True)``` . What I was seeing was that the field was not being updated operations calling to() and delete() since those operations use update() to shift order around.

This change adds an extra argument to those fields to allow me to pass {"modified": now()} to the operations that use to() and delete() and have the modified field on those objects that are updated properly reflect when they were changed.