### PR TITLE
Call queryset#filter with kwargs instead of args in get_ordering_queryset

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -42,7 +42,7 @@ class OrderedModelBase(models.Model):
         order_with_respect_to = self.order_with_respect_to
         if order_with_respect_to:
             order_values = self._get_order_with_respect_to()
-            qs = qs.filter(*order_values)
+            qs = qs.filter(**dict(order_values))
         return qs
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Official django documentation only allows passing kwargs.
https://docs.djangoproject.com/en/1.10/ref/models/querysets/#filter
Default QuerySet supports tuples, but third party libraries might not.
In particular, django-polymorphic does not support it.