### PR TITLE
Test on python 3.6 and with Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,22 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
-  - DJANGO="Django==1.10a1"
+  - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django>=1.11,<2.0"
 
 matrix:
   exclude:
     - python: "3.3"
       env: DJANGO="Django>=1.9,<1.10"
     - python: "3.3"
-      env: DJANGO="Django==1.10a1"
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: "3.3"
+      env: DJANGO="Django>=1.11,<2.0"
 
 # command to install dependencies
 install: pip install $DJANGO

--- a/ordered_model/tests/settings.py
+++ b/ordered_model/tests/settings.py
@@ -25,5 +25,10 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+            ],
+        },
     },
 ]


### PR DESCRIPTION
Without the auth context processor, the [tests fail](https://travis-ci.org/bfirsh/django-ordered-model/builds/217150940) with Django 1.11.