### PR TITLE
Use django.utils.six implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
   allow_failures:
   - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 install:
-- pip install six $DJANGO
+- pip install $DJANGO
 - python setup.py sdist
 - pip install dist/*
 script: script/test-command

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -1,9 +1,8 @@
 import warnings
-from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import Max, Min, F
 from django.utils.translation import ugettext as _
-import six
+from django.utils import six
 
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 Django
-six


### PR DESCRIPTION
As django includes an implementation of six, there is no need to require the six package itself ...

(I'm submitting that because I'm using zc.buildout and, for some reason, buildout does not pick up dependencies when they are proviced in a requirements.txt file)