### PR TITLE
Merge fix for #129 tested by  @sysradium

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -61,7 +61,7 @@ class OrderedModelAdmin(admin.ModelAdmin):
         redir_path = '%s%s%s' % (mangled, '/' if not mangled.endswith('/') else '',
             ('?' + iri_to_uri(request.META.get('QUERY_STRING', ''))) if request.META.get('QUERY_STRING', '') else '')
 
-        return HttpResponseRedirect(request.build_absolute_uri(location=redir_path))
+        return HttpResponseRedirect(redir_path)
 
     def move_up_down_links(self, obj):
         model_info = self._get_model_info()
@@ -241,7 +241,7 @@ class OrderedTabularInline(admin.TabularInline):
         redir_path = '%s%s%s' % (mangled, '/' if not mangled.endswith('/') else '',
             ('?' + iri_to_uri(request.META.get('QUERY_STRING', ''))) if request.META.get('QUERY_STRING', '') else '')
 
-        return HttpResponseRedirect(request.build_absolute_uri(location=redir_path))
+        return HttpResponseRedirect(redir_path)
 
     @classmethod
     def get_preserved_filters(cls, request):

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     # Django < 1.10
     from django.core.urlresolvers import reverse
-
+from django.utils.encoding import (escape_uri_path, iri_to_uri)
 
 class OrderedModelAdmin(admin.ModelAdmin):
     def get_urls(self):
@@ -56,7 +56,12 @@ class OrderedModelAdmin(admin.ModelAdmin):
         obj = get_object_or_404(self.model, pk=unquote(object_id))
         obj.move(direction, qs)
 
-        return HttpResponseRedirect('../../{0!s}'.format(self.request_query_string))
+        # guts from request.get_full_path(), calculating ../../ and restoring GET arguments
+        mangled = '/'.join(escape_uri_path(request.path).split('/')[0:-3])
+        redir_path = '%s%s%s' % (mangled, '/' if not mangled.endswith('/') else '',
+            ('?' + iri_to_uri(request.META.get('QUERY_STRING', ''))) if request.META.get('QUERY_STRING', '') else '')
+
+        return HttpResponseRedirect(request.build_absolute_uri(location=redir_path))
 
     def move_up_down_links(self, obj):
         model_info = self._get_model_info()
@@ -231,7 +236,12 @@ class OrderedTabularInline(admin.TabularInline):
         obj = get_object_or_404(cls.model, pk=unquote(object_id))
         obj.move(direction, qs)
 
-        return HttpResponseRedirect('../../../{0!s}'.format(cls.request_query_string))
+        # guts from request.get_full_path(), calculating ../../ and restoring GET arguments
+        mangled = '/'.join(escape_uri_path(request.path).split('/')[0:-4] + ['change'])
+        redir_path = '%s%s%s' % (mangled, '/' if not mangled.endswith('/') else '',
+            ('?' + iri_to_uri(request.META.get('QUERY_STRING', ''))) if request.META.get('QUERY_STRING', '') else '')
+
+        return HttpResponseRedirect(request.build_absolute_uri(location=redir_path))
 
     @classmethod
     def get_preserved_filters(cls, request):


### PR DESCRIPTION
The view that handle admin up/down links has _always_ been passed the GET query arguments used to build the admin page that rendered the links. Unfortunately the handler was not using them, relying on the state stored in global variable `self.request_query_string`. This variable would likely be incorrect if multiple worker threads are used (e.g. Gunicorn) or multiple users are on the admin site.

This patch removes that variable from the up/down handing view and generates suitable targets for the Redirect using the passed query arguments.