### PR TITLE
Fix #90: swap() follows documentation and takes an instance, and test

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -131,15 +131,21 @@ class OrderedModelBase(models.Model):
         )
         return self.up()
 
-    def swap(self, qs):
+    def _swap_qs0(self, qs):
         """
-        Swap the positions of this object with a reference object.
+        Swap the positions of this object with first result, if any, from the provided queryset.
         """
         try:
             replacement = qs[0]
         except IndexError:
             # already first/last
             return
+        self.swap(replacement)
+
+    def swap(self, replacement):
+        """
+        Swap the position of this object with a replacement object.
+        """
         if not self._valid_ordering_reference(replacement):
             raise ValueError(
                 "{0!r} can only be swapped with instances of {1!r} with equal {2!s} fields.".format(
@@ -156,7 +162,7 @@ class OrderedModelBase(models.Model):
         """
         Move this object up one position.
         """
-        self.swap(self.get_ordering_queryset()
+        self._swap_qs0(self.get_ordering_queryset()
                       .filter(**{self.order_field_name + '__lt': getattr(self, self.order_field_name)})
                       .order_by('-' + self.order_field_name))
 
@@ -164,7 +170,7 @@ class OrderedModelBase(models.Model):
         """
         Move this object down one position.
         """
-        self.swap(self.get_ordering_queryset().filter(**{self.order_field_name + '__gt': getattr(self, self.order_field_name)}))
+        self._swap_qs0(self.get_ordering_queryset().filter(**{self.order_field_name + '__gt': getattr(self, self.order_field_name)}))
 
     def to(self, order, extra_update=None):
         """

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -126,7 +126,14 @@ class OrderWithRespectToTests(TestCase):
 
     def test_swap(self):
         with self.assertRaises(ValueError):
-            self.q1_a1.swap([self.q2_a1])
+            self.q1_a1.swap(self.q2_a1)
+
+        self.q1_a1.swap(self.q1_a2)
+        self.assertSequenceEqual(
+            Answer.objects.values_list('pk', 'order'), [
+            (self.q1_a2.pk, 0), (self.q1_a1.pk, 1),
+            (self.q2_a1.pk, 0), (self.q2_a2.pk, 1)
+        ])
 
     def test_up(self):
         self.q1_a2.up()
@@ -434,7 +441,7 @@ class OrderWithRespectToTestsManyToMany(TestCase):
 
     def test_swap(self):
         with self.assertRaises(ValueError):
-            self.p1_t1.swap([self.p2_t1])
+            self.p1_t1.swap(self.p2_t1)
 
     def test_up(self):
         self.p1_t2.up()
@@ -522,7 +529,7 @@ class MultiOrderWithRespectToTests(TestCase):
 
     def test_swap_fails(self):
         with self.assertRaises(ValueError):
-            self.q1_u1_a1.swap([self.q2_u1_a2])
+            self.q1_u1_a1.swap(self.q2_u1_a2)
 
 
 class PolymorpicOrderGenerationTests(TestCase):


### PR DESCRIPTION
As noted on #90 the README documentation for the `swap()` operation on `OrderedModelBase` does not match the implementation. This patch assumes the documentation is correct, makes `swap()` behave intuitively and moves the use of _swap with a queryset_ behind private function `_swap_qs0()`. I've added an additional test that matches the documented behaviour.

I find it unlikely that swap-with-queryset is in widespread use, given the need to wrap the argument in a list, but happy to do a pull request to address in the release notes if you like?