### PR TITLE
Support order_with_respect_to on related fields. fixes #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ class PizzaToppingsThroughModel(OrderedModel):
         ordering = ('pizza', 'order')
 ```
 
+You can also specify `order_with_respect_to` to a field on a related model. An example use-case can be made with the following models:
+
+```python
+class ItemGroup(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    general_info = models.CharField(max_length=100)
+
+class GroupedItem(OrderedModel):
+    group = models.ForeignKey(ItemGroup, on_delete=models.CASCADE)
+    specific_info = models.CharField(max_length=100)
+    order_with_respect_to = 'group__user'
+```
+
+Here items are put into groups that have some general information used by its items, but the ordering of the items is independent of the group the item is in.
+
 When you want ordering on the baseclass instead of subclasses in an ordered list of objects of various classes, specify the full module path of the base class:
 
 ```python

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import reduce
 from django.db import models
 from django.db.models import Max, Min, F
 from django.utils.translation import ugettext as _
@@ -51,7 +52,9 @@ class OrderedModelBase(models.Model):
             raise AssertionError(('ordered model admin "{0}" has not specified "order_with_respect_to"; note that this '
                 'should go in the model body, and is not to be confused with the Meta property of the same name, '
                 'which is independent Django functionality').format(self))
-        return [(field, getattr(self, field)) for field in self.order_with_respect_to]
+        def get_field_tuple(field):
+            return (field, reduce(lambda i, f: getattr(i, f), field.split('__'), self))
+        return list(map(get_field_tuple, self.order_with_respect_to))
 
     def _valid_ordering_reference(self, reference):
         return self.order_with_respect_to is None or (

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -72,3 +72,10 @@ class MultipleChoiceQuestion(BaseQuestion):
 
 class OpenQuestion(BaseQuestion):
     answer = models.TextField(max_length=100)
+
+class ItemGroup(models.Model):
+    user = models.ForeignKey(TestUser, on_delete=models.CASCADE, related_name='item_groups')
+
+class GroupedItem(OrderedModel):
+    group = models.ForeignKey(ItemGroup, on_delete=models.CASCADE, related_name='items')
+    order_with_respect_to = 'group__user'


### PR DESCRIPTION
A feature I use/need on production servers.

Behaviour should be the same as the original code for `order_with_respect_to` fields that do not contain double underscores (which I doubt anyone using django would use).