### PR TITLE
Drop support for Django < 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ python:
 - '3.5'
 - '3.6'
 env:
-- DJANGO="Django>=1.8,<1.9"
-- DJANGO="Django>=1.9,<1.10"
-- DJANGO="Django>=1.10,<1.11"
 - DJANGO="Django>=1.11,<2.0"
 - DJANGO="Django>=2.0,<2.1"
 - DJANGO="https://github.com/django/django/archive/master.tar.gz"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://djangosnippets.org/snippets/259/
 
 Requires:
 
-  * Django >=1.8
+  * Django >=1.11
   * Python 2.7 or >=3.4
 
 Installation

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -4,18 +4,14 @@ from django.conf.urls import url
 from django.core.paginator import Paginator
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.encoding import escape_uri_path, iri_to_uri
 from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
 
-try:
-    from django.urls import reverse
-except ImportError:
-    # Django < 1.10
-    from django.core.urlresolvers import reverse
-from django.utils.encoding import (escape_uri_path, iri_to_uri)
 
 class OrderedModelAdmin(admin.ModelAdmin):
     def get_urls(self):

--- a/ordered_model/tests/settings.py
+++ b/ordered_model/tests/settings.py
@@ -25,10 +25,6 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-# Compatibility for Django < 1.10
-if django.VERSION < (1, 10):
-    MIDDLEWARE_CLASSES = MIDDLEWARE
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
According to Supported Versions in https://www.djangoproject.com/download/ all these version reached their end of life.

The django maintainers suggested to drop support for Django < 1.11 in third party libraries with the release of Django 2.0 at December 2, 2017. See https://docs.djangoproject.com/en/2.0/releases/2.0/#third-party-library-support-for-older-version-of-django

I'd recommend making a release with official Django 2.0 support before merging this.