### PR TITLE
Fix inline ordered model

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -141,26 +141,7 @@ class OrderedInlineMixin(object):
             # Use only the first item in list_display as link
             return list(list_display)[:1]
 
-    @classmethod
-    def _get_changelist(cls, request):
-        list_display = cls.get_list_display(request)
-        list_display_links = cls.get_list_display_links(request, list_display)
-
-        cl = ChangeList(request, cls.model, list_display,
-                        list_display_links, cls.list_filter, cls.date_hierarchy,
-                        cls.search_fields, cls.list_select_related,
-                        cls.list_per_page, cls.list_max_show_all, cls.list_editable,
-                        cls)
-
-        return cl
-
     request_query_string = ''
-
-    @classmethod
-    def changelist_view(cls, request, extra_context=None):
-        cl = cls._get_changelist(request)
-        cls.request_query_string = cl.get_query_string()
-        return super(OrderedTabularInline, cls).changelist_view(request, extra_context)
 
     @classmethod
     def get_queryset(cls, request):
@@ -230,7 +211,7 @@ class OrderedInlineMixin(object):
 
     @classmethod
     def move_view(cls, request, admin_id, object_id, direction):
-        qs = cls._get_changelist(request).get_queryset(request)
+        qs = cls.get_queryset(request)
 
         obj = get_object_or_404(cls.model, pk=unquote(object_id))
         obj.move(direction, qs)

--- a/ordered_model/tests/admin.py
+++ b/ordered_model/tests/admin.py
@@ -1,8 +1,31 @@
 from django.contrib import admin
-from ordered_model.admin import OrderedModelAdmin
-from .models import Item
+from ordered_model.admin import OrderedModelAdmin, OrderedTabularInline
+from .models import Item, PizzaToppingsThroughModel, Pizza
+
 
 class ItemAdmin(OrderedModelAdmin):
     list_display = ('name', 'move_up_down_links')
 
+
+class PizzaToppingTabularInline(OrderedTabularInline):
+    model = PizzaToppingsThroughModel
+    fields = ('order', 'move_up_down_links',)
+    readonly_fields = ('order', 'move_up_down_links',)
+    ordering = ('order',)
+
+
+class PizzaAdmin(admin.ModelAdmin):
+    model = Pizza
+    list_display = ('name',)
+    inlines = (PizzaToppingTabularInline,)
+
+    def get_urls(self):
+        urls = super(PizzaAdmin, self).get_urls()
+        for inline in self.inlines:
+            if hasattr(inline, 'get_urls'):
+                urls = inline.get_urls(self) + urls
+        return urls
+
+
 admin.site.register(Item, ItemAdmin)
+admin.site.register(Pizza, PizzaAdmin)

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -388,7 +388,7 @@ class OrderedModelAdminTest(TestCase):
 
         self.ham = Topping.objects.create(name='Ham')
         self.pineapple = Topping.objects.create(name='Pineapple')
-        self.pizza = Pizza.objects.create(name='Hawaiin Pizza')
+        self.pizza = Pizza.objects.create(name='Hawaiian Pizza')
         self.pizza_to_ham = PizzaToppingsThroughModel.objects.create(pizza=self.pizza, topping=self.ham)
         self.pizza_to_pineapple = PizzaToppingsThroughModel.objects.create(pizza=self.pizza, topping=self.pineapple)
 


### PR DESCRIPTION
@bfirsh This is the failing test in Django 2.1. I'm struggling a bit in how to fix, not sure I quite understand the inner workings of the admin integration. Simply copying the logic from the OrderAdmin model doesn't work since there seems to be a dependency on using `self` the instance rather than `cls`, which is how `_get_changelist` is called