### PR TITLE
Fix django21 inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ For the `OrderedTabularInline` it will look like this:
 
 ```python
 from django.contrib import admin
-from ordered_model.admin import OrderedTabularInline
+from ordered_model.admin import OrderedTabularInline, OrderedInlineModelAdminMixin
 from models import Pizza, PizzaToppingsThroughModel
 
 
@@ -249,16 +249,10 @@ class PizzaToppingsThroughModelTabularInline(OrderedTabularInline):
     ordering = ('order',)
 
 
-class PizzaAdmin(admin.ModelAdmin):
+class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
     list_display = ('name', )
     inlines = (PizzaToppingsThroughModelTabularInline, )
 
-    def get_urls(self):
-        urls = super(PizzaAdmin, self).get_urls()
-        for inline in self.inlines:
-            if hasattr(inline, 'get_urls'):
-                urls = inline.get_urls(self) + urls
-        return urls
 
 admin.site.register(Pizza, PizzaAdmin)
 ```
@@ -268,7 +262,7 @@ For the `OrderedStackedInline` it will look like this:
 
 ```python
 from django.contrib import admin
-from ordered_model.admin import OrderedStackedInline
+from ordered_model.admin import OrderedStackedInline, OrderedInlineModelAdminMixin
 from models import Pizza, PizzaToppingsThroughModel
 
 
@@ -280,16 +274,10 @@ class PizzaToppingsThroughModelStackedInline(OrderedStackedInline):
     ordering = ('order',)
 
 
-class PizzaAdmin(admin.ModelAdmin):
+class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
     list_display = ('name', )
     inlines = (PizzaToppingsThroughModelStackedInline, )
 
-    def get_urls(self):
-        urls = super(PizzaAdmin, self).get_urls()
-        for inline in self.inlines:
-            if hasattr(inline, 'get_urls'):
-                urls = inline.get_urls(self) + urls
-        return urls
 
 admin.site.register(Pizza, PizzaAdmin)
 ```

--- a/ordered_model/tests/admin.py
+++ b/ordered_model/tests/admin.py
@@ -1,8 +1,31 @@
 from django.contrib import admin
-from ordered_model.admin import OrderedModelAdmin
-from .models import Item
+from ordered_model.admin import OrderedModelAdmin, OrderedTabularInline
+from .models import Item, PizzaToppingsThroughModel, Pizza
+
 
 class ItemAdmin(OrderedModelAdmin):
     list_display = ('name', 'move_up_down_links')
 
+
+class PizzaToppingTabularInline(OrderedTabularInline):
+    model = PizzaToppingsThroughModel
+    fields = ('order', 'move_up_down_links',)
+    readonly_fields = ('order', 'move_up_down_links',)
+    ordering = ('order',)
+
+
+class PizzaAdmin(admin.ModelAdmin):
+    model = Pizza
+    list_display = ('name',)
+    inlines = (PizzaToppingTabularInline,)
+
+    def get_urls(self):
+        urls = super(PizzaAdmin, self).get_urls()
+        for inline in self.inlines:
+            if hasattr(inline, 'get_urls'):
+                urls = inline.get_urls(self) + urls
+        return urls
+
+
 admin.site.register(Item, ItemAdmin)
+admin.site.register(Pizza, PizzaAdmin)

--- a/ordered_model/tests/admin.py
+++ b/ordered_model/tests/admin.py
@@ -1,5 +1,11 @@
 from django.contrib import admin
-from ordered_model.admin import OrderedModelAdmin, OrderedTabularInline
+
+from ordered_model.admin import (
+    OrderedModelAdmin,
+    OrderedTabularInline,
+    OrderedInlineModelAdminMixin
+)
+
 from .models import Item, PizzaToppingsThroughModel, Pizza
 
 
@@ -14,17 +20,10 @@ class PizzaToppingTabularInline(OrderedTabularInline):
     ordering = ('order',)
 
 
-class PizzaAdmin(admin.ModelAdmin):
+class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
     model = Pizza
     list_display = ('name',)
     inlines = (PizzaToppingTabularInline,)
-
-    def get_urls(self):
-        urls = super(PizzaAdmin, self).get_urls()
-        for inline in self.inlines:
-            if hasattr(inline, 'get_urls'):
-                urls = inline.get_urls(self) + urls
-        return urls
 
 
 admin.site.register(Item, ItemAdmin)

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -388,7 +388,8 @@ class OrderedModelAdminTest(TestCase):
 
         self.ham = Topping.objects.create(name='Ham')
         self.pineapple = Topping.objects.create(name='Pineapple')
-        self.pizza = Pizza.objects.create(name='Hawaiin Pizza')
+
+        self.pizza = Pizza.objects.create(name='Hawaiian Pizza')
         self.pizza_to_ham = PizzaToppingsThroughModel.objects.create(pizza=self.pizza, topping=self.ham)
         self.pizza_to_pineapple = PizzaToppingsThroughModel.objects.create(pizza=self.pizza, topping=self.pineapple)
 


### PR DESCRIPTION
Fix https://github.com/bfirsh/django-ordered-model/issues/152 issue with django 2.1 and also refactor `OrderedInlineMixin` to use regular methods instead of classmehods. This is probably only correct way to have them working after latest changes in django

@bfirsh This is initial version, we probably have to release it under version 3.x because this is braking change. Do you have any comments against this approach? 