### PR TITLE
Helps prevent deadlocks

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -720,3 +720,33 @@ class PolymorpicOrderGenerationTests(TestCase):
         self.assertEqual(o2.order, 2)
         m1.refresh_from_db()
         self.assertEqual(m1.order, 3)
+
+
+class TestFixInOrdering(TestCase):
+    def test_that_when_multiple_models_are_updated_simultaneously_it_will_not_break(self):
+        """
+        This is a test that tests the case where:
+        Request 1 and 2 happen simultaneously.
+        They both load a CustomItem into memory from database, and try to move them around.
+        We want to ensure consistency.
+        """
+        # Three items are created here
+        item0 = CustomItem.objects.create(id="0", name='0')
+        item1 = CustomItem.objects.create(id="1", name='1')
+        item2 = CustomItem.objects.create(id="2", name='2')
+
+        # Moving item 0 to position 2. This works fine, and moves item 1 to position 0
+        item0.to(2)
+
+        # Item 1 now is *actually* in position 0, but thinks it's in position 1. As we refresh
+        # the value from the database, this is not a problem
+        item1.to(2)
+
+        item0.refresh_from_db()
+        item1.refresh_from_db()
+        item2.refresh_from_db()
+
+        # All orders are correct now.
+        self.assertEqual(item2.order, 0)
+        self.assertEqual(item0.order, 1)
+        self.assertEqual(item1.order, 2)


### PR DESCRIPTION
Partially fixes #184 

This takes the steps outlined in #184 to prevent deadlocks and data inconsistencies.
It locks rows before updating them, on databases that support this. Unfortunately since the testing suite uses SQLite I haven't been able to write a test for this, and I was not comfortable changing the testing DB.

I've also made a change so that `to()` always fetches the newest value from the database, which is necessary because otherwise we can end up in situations where there's inconsistencies with concurrent connections. I've added a test for this that was failing before the changes, but is passing now.
I haven't gone through and checked whether or not other methods than `to` should have the same optimization applied.