### PR TITLE
Explicitly order queryset when searching for next item

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -53,7 +53,9 @@ class OrderedModelQuerySet(models.QuerySet):
     def above(self, order, inclusive=False):
         """Filter items above order."""
         lookup = "gte" if inclusive else "gt"
-        return self.filter(**{self._get_order_field_lookup(lookup): order}).order_by(self._get_order_field_name())
+        return self.filter(**{self._get_order_field_lookup(lookup): order}).order_by(
+            self._get_order_field_name()
+        )
 
     def above_instance(self, ref, inclusive=False):
         """Filter items above ref's order."""
@@ -64,7 +66,9 @@ class OrderedModelQuerySet(models.QuerySet):
     def below(self, order, inclusive=False):
         """Filter items below order."""
         lookup = "lte" if inclusive else "lt"
-        return self.filter(**{self._get_order_field_lookup(lookup): order}).order_by(self._get_order_field_name())
+        return self.filter(**{self._get_order_field_lookup(lookup): order}).order_by(
+            self._get_order_field_name()
+        )
 
     def below_instance(self, ref, inclusive=False):
         """Filter items below ref's order."""

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -53,7 +53,7 @@ class OrderedModelQuerySet(models.QuerySet):
     def above(self, order, inclusive=False):
         """Filter items above order."""
         lookup = "gte" if inclusive else "gt"
-        return self.filter(**{self._get_order_field_lookup(lookup): order})
+        return self.filter(**{self._get_order_field_lookup(lookup): order}).order_by(self._get_order_field_name())
 
     def above_instance(self, ref, inclusive=False):
         """Filter items above ref's order."""
@@ -64,7 +64,7 @@ class OrderedModelQuerySet(models.QuerySet):
     def below(self, order, inclusive=False):
         """Filter items below order."""
         lookup = "lte" if inclusive else "lt"
-        return self.filter(**{self._get_order_field_lookup(lookup): order})
+        return self.filter(**{self._get_order_field_lookup(lookup): order}).order_by(self._get_order_field_name())
 
     def below_instance(self, ref, inclusive=False):
         """Filter items below ref's order."""

--- a/script/test
+++ b/script/test
@@ -4,6 +4,7 @@ docker build -t django-ordered-model -f - . << EOS
 FROM python:3
 WORKDIR /code
 RUN pip install django==2.0
+RUN pip install coverage
 VOLUME /code
 EOS
 docker run -v $PWD:/code django-ordered-model script/test-command
@@ -13,6 +14,7 @@ docker build -t django-ordered-model -f - . << EOS
 FROM python:3
 WORKDIR /code
 RUN pip install django==2.1
+RUN pip install coverage
 VOLUME /code
 EOS
 docker run -v $PWD:/code django-ordered-model script/test-command

--- a/tests/models.py
+++ b/tests/models.py
@@ -98,4 +98,4 @@ class CustomMetaItem(OrderedModel):
     name = models.CharField(max_length=100)
 
     class Meta:
-        db_table = 'custom_meta_item'
+        db_table = "custom_meta_item"

--- a/tests/models.py
+++ b/tests/models.py
@@ -92,3 +92,10 @@ class ItemGroup(models.Model):
 class GroupedItem(OrderedModel):
     group = models.ForeignKey(ItemGroup, on_delete=models.CASCADE, related_name="items")
     order_with_respect_to = "group__user"
+
+
+class CustomMetaItem(OrderedModel):
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        db_table = 'custom_meta_item'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,6 +18,7 @@ from tests.models import (
     ItemGroup,
     GroupedItem,
     TestUser,
+    CustomMetaItem,
 )
 
 
@@ -920,4 +921,45 @@ class BulkCreateTests(TestCase):
                 "order", flat=True
             ),
             [0, 1],
+        )
+
+
+class CustomMetaTest(TestCase):
+    def setUp(self):
+        self.item1 = CustomMetaItem.objects.create(name='one')
+        self.item2 = CustomMetaItem.objects.create(name='two')
+        self.item3 = CustomMetaItem.objects.create(name='three')
+        self.item4 = CustomMetaItem.objects.create(name='four')
+
+    def test_saved_order(self):
+        self.assertSequenceEqual(
+            CustomMetaItem.objects.order_by('order').values_list('pk', 'order'), [
+                (self.item1.pk, 0),
+                (self.item2.pk, 1),
+                (self.item3.pk, 2),
+                (self.item4.pk, 3)
+            ]
+        )
+
+    def test_next_order(self):
+        self.item1.bottom()
+        self.assertSequenceEqual(
+            CustomMetaItem.objects.order_by('order').values_list('pk', 'order'), [
+                (self.item2.pk, 0),
+                (self.item3.pk, 1),
+                (self.item4.pk, 2),
+                (self.item1.pk, 3)
+            ]
+        )
+
+        top = CustomMetaItem.objects.order_by('order').first()
+
+        top.down()
+        self.assertSequenceEqual(
+            CustomMetaItem.objects.order_by('order').values_list('pk', 'order'), [
+                (self.item3.pk, 0),
+                (self.item2.pk, 1),
+                (self.item4.pk, 2),
+                (self.item1.pk, 3)
+            ]
         )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -926,40 +926,43 @@ class BulkCreateTests(TestCase):
 
 class CustomMetaTest(TestCase):
     def setUp(self):
-        self.item1 = CustomMetaItem.objects.create(name='one')
-        self.item2 = CustomMetaItem.objects.create(name='two')
-        self.item3 = CustomMetaItem.objects.create(name='three')
-        self.item4 = CustomMetaItem.objects.create(name='four')
+        self.item1 = CustomMetaItem.objects.create(name="one")
+        self.item2 = CustomMetaItem.objects.create(name="two")
+        self.item3 = CustomMetaItem.objects.create(name="three")
+        self.item4 = CustomMetaItem.objects.create(name="four")
 
     def test_saved_order(self):
         self.assertSequenceEqual(
-            CustomMetaItem.objects.order_by('order').values_list('pk', 'order'), [
+            CustomMetaItem.objects.order_by("order").values_list("pk", "order"),
+            [
                 (self.item1.pk, 0),
                 (self.item2.pk, 1),
                 (self.item3.pk, 2),
-                (self.item4.pk, 3)
-            ]
+                (self.item4.pk, 3),
+            ],
         )
 
     def test_next_order(self):
         self.item1.bottom()
         self.assertSequenceEqual(
-            CustomMetaItem.objects.order_by('order').values_list('pk', 'order'), [
+            CustomMetaItem.objects.order_by("order").values_list("pk", "order"),
+            [
                 (self.item2.pk, 0),
                 (self.item3.pk, 1),
                 (self.item4.pk, 2),
-                (self.item1.pk, 3)
-            ]
+                (self.item1.pk, 3),
+            ],
         )
 
-        top = CustomMetaItem.objects.order_by('order').first()
+        top = CustomMetaItem.objects.order_by("order").first()
 
         top.down()
         self.assertSequenceEqual(
-            CustomMetaItem.objects.order_by('order').values_list('pk', 'order'), [
+            CustomMetaItem.objects.order_by("order").values_list("pk", "order"),
+            [
                 (self.item3.pk, 0),
                 (self.item2.pk, 1),
                 (self.item4.pk, 2),
-                (self.item1.pk, 3)
-            ]
+                (self.item1.pk, 3),
+            ],
         )


### PR DESCRIPTION
Calls to next() may produce incorrect results in cases where
a model's Meta class has been defined without a compatible
ordering attribute