### PR TITLE
Preserve original order field in bulk_create (second try)

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -107,9 +107,15 @@ class OrderedModelQuerySet(models.QuerySet):
                     ] = self.filter_by_order_with_respect_to(obj).get_next_order()
                 setattr(obj, order_field_name, order_with_respect_to_mapping[key])
         else:
-            for order, obj in enumerate(objs, self.get_next_order()):
-                setattr(obj, order_field_name, order)
-        return super().bulk_create(objs, batch_size=batch_size)
+            next_order = self.get_next_order()
+            for obj in objs:
+                orig_order = getattr(obj, order_field_name)
+                if orig_order is None:
+                    setattr(obj, order_field_name, next_order)
+                    next_order += 1
+                else:
+                    next_order = max(next_order, orig_order + 1)
+        super().bulk_create(objs, batch_size=batch_size)
 
     def _get_order_with_respect_to_filter_kwargs(self, ref):
         order_with_respect_to = self._get_order_with_respect_to()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -925,3 +925,9 @@ class BulkCreateTests(TestCase):
             ),
             [0, 1],
         )
+
+
+class TestDiangoSerializer(TestCase):
+    def test(self):
+        Item.objects.bulk_create([Item(name="1", order=1), Item(name="2", order=0)])
+        self.assertSequenceEqual(Item.objects.all().values_list("name", flat=True), ["2", "1"])


### PR DESCRIPTION
I've found the case when `bulk_create` fails to create correct objects and added the test as you requested.