### PR TITLE
Mention a workaround the "No Reverse Match" error in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
 admin.site.register(Pizza, PizzaAdmin)
 ```
 
-**Note:** `OrderedModelAdmin` requires the inline subclasses of `OrderedTabularInline` and `OrderedStackedInline` to be listed on `inlines`. If you are using `get_inlines()` or `get_inline_instances()` to return the list of inlines, make sure that the returned inlines are defined in `inlines` too or you might encounter a “No Reverse Match” error when accessing model change view.
+**Note:** `OrderedModelAdmin` requires the inline subclasses of `OrderedTabularInline` and `OrderedStackedInline` to be listed on `inlines` so that we register appropriate URL routes. If you are using Django 3.0 feature `get_inlines()` or `get_inline_instances()` to return the list of inlines dynamically, consider it a filter and still add them to `inlines` or you might encounter a “No Reverse Match” error when accessing model change view.
 
 Re-ordering models
 ------------------

--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
 admin.site.register(Pizza, PizzaAdmin)
 ```
 
+**Note:** `OrderedModelAdmin` requires the inline subclasses of `OrderedTabularInline` and `OrderedStackedInline` to be listed on `inlines`. If you are using `get_inlines()` or `get_inline_instances()` to return the list of inlines, make sure that the returned inlines are defined in `inlines` too or you might encounter a “No Reverse Match” error when accessing model change view.
+
 Re-ordering models
 ------------------
 


### PR DESCRIPTION
This quick patch to the documentation adds a mention about a workaround the "No Reverse Match" error if the user is using `get_inlines()` or `get_inline_instances()` to return the list of `OrderedTabularInline` and `OrderedStackedInline` inlines instead of `inlines` in `OrderedModelAdmin`.

The cause of the error is `get_urls()` in `OrderedModelAdmin` which iterates just the `inlines` field to get the urls of the inlined `OrderedTabularInline` and `OrderedStackedInline`.