### PR TITLE
Run tests against Django 3.1 & 3.2 and Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - python setup.py sdist bdist_wheel
   - pip install dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - "3.9"
 install:
   - python setup.py sdist bdist_wheel
-  - pip install dist/*
-  - pip install tox-travis codecov
+  - python -m pip install dist/*.whl
+  - python -m pip install tox-travis codecov
 script: tox
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Compatibility with Django and Python
 
 |django-ordered-model version | Django version      | Python version
 |-----------------------------|---------------------|--------------------
-| **3.4.x**                   | **2.x**             | **3.5** and above
+| **3.4.x**                   | **2.x**, **3.x**    | **3.5** and above
 | **3.3.x**                   | **2.x**             | **3.4** and above
 | **3.2.x**                   | **2.x**             | **3.4** and above
 | **3.1.x**                   | **2.x**             | **3.4** and above

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{35,36,37,38}-django22
     py{36,37,38}-django30
     py{36,37,38}-django31
+    py{36,37,38}-django32
     py{36,37,38}-djangoupstream
     black
 
@@ -15,6 +16,7 @@ deps =
     django22: Django~=2.2.0
     django30: Django~=3.0.0
     django31: Django~=3.1.0
+    django32: Django~=3.2.0
     djangoupstream: https://github.com/django/django/archive/master.tar.gz
     coverage
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -2,20 +2,20 @@
 envlist =
     py{34,35,36,37}-django20
     py{35,36,37}-django21
-    py{35,36,37,38}-django22
-    py{36,37,38}-django30
-    py{36,37,38}-django31
-    py{36,37,38}-django32
-    py{36,37,38}-djangoupstream
+    py{35,36,37,38,39}-django22
+    py{36,37,38,39}-django30
+    py{36,37,38,39}-django31
+    py{36,37,38,39}-django32
+    py{36,37,38,39}-djangoupstream
     black
 
 [testenv]
 deps =
     django20: Django~=2.0.0
     django21: Django~=2.1.0
-    django22: Django~=2.2.0
-    django30: Django~=3.0.0
-    django31: Django~=3.1.0
+    django22: Django~=2.2.17
+    django30: Django~=3.0.11
+    django31: Django~=3.1.3
     django32: Django~=3.2.0
     djangoupstream: https://github.com/django/django/archive/main.tar.gz
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     djangoupstream: https://github.com/django/django/archive/main.tar.gz
     coverage
 commands =
-    coverage run {envbindir}/django-admin.py test --pythonpath=. --settings=tests.settings {posargs}
+    coverage run {envbindir}/django-admin test --pythonpath=. --settings=tests.settings {posargs}
 
 [testenv:black]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32
-    py{36,37,38,39}-djangoupstream
+    py{38,39}-djangoupstream
     black
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     django30: Django~=3.0.0
     django31: Django~=3.1.0
     django32: Django~=3.2.0
-    djangoupstream: https://github.com/django/django/archive/master.tar.gz
+    djangoupstream: https://github.com/django/django/archive/main.tar.gz
     coverage
 commands =
     coverage run {envbindir}/django-admin.py test --pythonpath=. --settings=tests.settings {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{35,36,37}-django21
     py{35,36,37,38}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
     py{36,37,38}-djangoupstream
     black
 
@@ -13,6 +14,7 @@ deps =
     django21: Django~=2.1
     django22: Django~=2.2
     django30: Django~=3.0
+    django31: Django~=3.1
     djangoupstream: https://github.com/django/django/archive/master.tar.gz
     coverage
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@ envlist =
 
 [testenv]
 deps =
-    django20: Django~=2.0
-    django21: Django~=2.1
-    django22: Django~=2.2
-    django30: Django~=3.0
-    django31: Django~=3.1
+    django20: Django~=2.0.0
+    django21: Django~=2.1.0
+    django22: Django~=2.2.0
+    django30: Django~=3.0.0
+    django31: Django~=3.1.0
     djangoupstream: https://github.com/django/django/archive/master.tar.gz
     coverage
 commands =


### PR DESCRIPTION
It also fixes the selection of django's version used for testing.  See eg. https://travis-ci.org/github/bfirsh/django-ordered-model/jobs/699599545#L360-L362

Beginning and end of selection:

![image](https://user-images.githubusercontent.com/152008/89348984-fe6cb200-d69c-11ea-9d88-704f854a0447.png)
