### PR TITLE
Replaces id with pk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+Unreleased
+----------
+
+- Fix `OrderedTabularInline` for models with custom primary key field (#233)
+
 3.4.1 - 2020-05-11
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -335,10 +335,17 @@ admin.site.register(Pizza, PizzaAdmin)
 Test suite
 ----------
 
-Requires Docker.
+To run the tests against your current environment, use:
 
 ```bash
-$ script/test
+$ django-admin test --pythonpath=. --settings=tests.settings
+```
+
+Otherwise please install `tox` and run the tests for a specific environment with `-e` or all environments:
+
+```bash
+$ tox -e py36-django30
+$ tox
 ```
 
 Compatibility with Django and Python

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -193,7 +193,7 @@ class OrderedInlineMixin(BaseOrderedModelAdmin):
         return HttpResponseRedirect(redir_path)
 
     def move_up_down_links(self, obj):
-        if not obj.id:
+        if not obj.pk:
             return ""
 
         # Find the fields which refer to the parent model of this inline, and
@@ -225,25 +225,25 @@ class OrderedInlineMixin(BaseOrderedModelAdmin):
                             "{admin_name}:{app}_{model}_change_order_inline".format(
                                 admin_name=self.admin_site.name, **model_info
                             ),
-                            args=[order_obj_name, obj.id, "up"],
+                            args=[order_obj_name, obj.pk, "up"],
                         ),
                         "down": reverse(
                             "{admin_name}:{app}_{model}_change_order_inline".format(
                                 admin_name=self.admin_site.name, **model_info
                             ),
-                            args=[order_obj_name, obj.id, "down"],
+                            args=[order_obj_name, obj.pk, "down"],
                         ),
                         "top": reverse(
                             "{admin_name}:{app}_{model}_change_order_inline".format(
                                 admin_name=self.admin_site.name, **model_info
                             ),
-                            args=[order_obj_name, obj.id, "top"],
+                            args=[order_obj_name, obj.pk, "top"],
                         ),
                         "bottom": reverse(
                             "{admin_name}:{app}_{model}_change_order_inline".format(
                                 admin_name=self.admin_site.name, **model_info
                             ),
-                            args=[order_obj_name, obj.id, "bottom"],
+                            args=[order_obj_name, obj.pk, "bottom"],
                         ),
                     },
                     "query_string": self.request_query_string,

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -6,7 +6,13 @@ from ordered_model.admin import (
     OrderedInlineModelAdminMixin,
 )
 
-from .models import Item, PizzaToppingsThroughModel, Pizza
+from .models import (
+    Item,
+    PizzaToppingsThroughModel,
+    Pizza,
+    CustomPKGroupItem,
+    CustomPKGroup,
+)
 
 
 class ItemAdmin(OrderedModelAdmin):
@@ -26,5 +32,17 @@ class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
     inlines = (PizzaToppingTabularInline,)
 
 
+class CustomPKGroupItemInline(OrderedTabularInline):
+    model = CustomPKGroupItem
+    fields = ("name", "order", "move_up_down_links")
+    readonly_fields = ("order", "move_up_down_links")
+
+
+class CustomPKGroupAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
+    model = CustomPKGroup
+    inlines = (CustomPKGroupItemInline,)
+
+
 admin.site.register(Item, ItemAdmin)
 admin.site.register(Pizza, PizzaAdmin)
+admin.site.register(CustomPKGroup, CustomPKGroupAdmin)

--- a/tests/models.py
+++ b/tests/models.py
@@ -32,11 +32,13 @@ class Answer(OrderedModel):
             self.order, self.question_id, self.user_id
         )
 
+
 # test ordering whilst overriding the automatic primary key (ie. not models.Model.id)
 class CustomItem(OrderedModel):
     pkid = models.CharField(max_length=100, primary_key=True)
     name = models.CharField(max_length=100)
     modified = models.DateTimeField(null=True, blank=True)
+
 
 # test ordering over custom ordering field (ie. not OrderedModel.order)
 class CustomOrderFieldModel(OrderedModelBase):
@@ -67,6 +69,21 @@ class PizzaToppingsThroughModel(OrderedModel):
         ordering = ("pizza", "order")
 
 
+# test many-one where the item has custom PK
+
+
+class CustomPKGroup(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class CustomPKGroupItem(OrderedModel):
+    group = models.ForeignKey(CustomPKGroup, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100, primary_key=True)
+    order_with_respect_to = "group"
+
+
+# test ordering on a base class (with order_class_path)
+# ie. OpenQuestion and GroupedItem can be ordered wrt each other
 class BaseQuestion(OrderedModel):
     order_class_path = __module__ + ".BaseQuestion"
     question = models.TextField(max_length=100)

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,10 +3,12 @@ from django.db import models
 from ordered_model.models import OrderedModel, OrderedModelBase
 
 
+# test simple automatic ordering
 class Item(OrderedModel):
     name = models.CharField(max_length=100)
 
 
+# test Answer.order_with_respect_to being a tuple
 class Question(models.Model):
     pass
 
@@ -30,13 +32,13 @@ class Answer(OrderedModel):
             self.order, self.question_id, self.user_id
         )
 
-
+# test ordering whilst overriding the automatic primary key (ie. not models.Model.id)
 class CustomItem(OrderedModel):
-    id = models.CharField(max_length=100, primary_key=True)
+    pkid = models.CharField(max_length=100, primary_key=True)
     name = models.CharField(max_length=100)
     modified = models.DateTimeField(null=True, blank=True)
 
-
+# test ordering over custom ordering field (ie. not OrderedModel.order)
 class CustomOrderFieldModel(OrderedModelBase):
     sort_order = models.PositiveIntegerField(editable=False, db_index=True)
     name = models.CharField(max_length=100)
@@ -46,6 +48,7 @@ class CustomOrderFieldModel(OrderedModelBase):
         ordering = ("sort_order",)
 
 
+# test ThroughModel ordering with Pizzas/Topping
 class Topping(models.Model):
     name = models.CharField(max_length=100)
 
@@ -83,6 +86,7 @@ class OpenQuestion(BaseQuestion):
     answer = models.TextField(max_length=100)
 
 
+# test grouping by a foreign model field (group__user)
 class ItemGroup(models.Model):
     user = models.ForeignKey(
         TestUser, on_delete=models.CASCADE, related_name="item_groups"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -273,10 +273,10 @@ class OrderWithRespectToTests(TestCase):
 
 class CustomPKTest(TestCase):
     def setUp(self):
-        self.item1 = CustomItem.objects.create(id=str(uuid.uuid4()), name="1")
-        self.item2 = CustomItem.objects.create(id=str(uuid.uuid4()), name="2")
-        self.item3 = CustomItem.objects.create(id=str(uuid.uuid4()), name="3")
-        self.item4 = CustomItem.objects.create(id=str(uuid.uuid4()), name="4")
+        self.item1 = CustomItem.objects.create(pkid=str(uuid.uuid4()), name="1")
+        self.item2 = CustomItem.objects.create(pkid=str(uuid.uuid4()), name="2")
+        self.item3 = CustomItem.objects.create(pkid=str(uuid.uuid4()), name="3")
+        self.item4 = CustomItem.objects.create(pkid=str(uuid.uuid4()), name="4")
 
     def test_saved_order(self):
         self.assertSequenceEqual(


### PR DESCRIPTION
move_up_down_links method doesn't work with models with custom primary keys. To fix this I suggest to use pk instead of id.
The [pk property](https://docs.djangoproject.com/en/3.1/ref/models/instances/#the-pk-property) will cover both cases.
