### PR TITLE
README suggested changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ See our [compatability notes](#compatibility-with-django-and-python) for the app
 Installation
 ------------
 
-```bash
-$ python setup.py install
-```
-
-You can use Pip:
+Please install using Pip:
 
 ```bash
 $ pip install django-ordered-model
+```
+
+Or if you have checked out the repository:
+
+```bash
+$ python setup.py install
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ foo.previous()
 foo.next()
 ```
 
-previous() and next() get the neighbouring objects directly above of below
-within the ordered stack depending on the direction.
+The `previous()` and `next()` methods return the neighbouring objects directly above or below
+within the ordered stack.
 
 ## Subset Ordering
 


### PR DESCRIPTION
Installation instructions put pip first
Reword next/previous method working